### PR TITLE
remove the requirement for event name in logging

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -142,3 +142,15 @@ logging pipeline activities.
 const p = createPipeline(stage1, stage2).as('my-awesome-pipeline');
 p();
 ```
+
+## Logging
+There is a defined logger which has been integrated into the context, the default levels are :
+- debug
+- info 
+- warn
+- error
+
+To use the logger you just need to invoke the level on the context
+```
+context.log.debug(<data object>);
+```

--- a/src/context.js
+++ b/src/context.js
@@ -54,7 +54,7 @@ const appendToContext = (context, newProps) => {
   return context;
 };
 
-const extractProps = context =>  context._props;
+const extractProps = context => context._props;
 
 /**
  * Context is type used to share data/services between independent stages

--- a/src/createEventLog.js
+++ b/src/createEventLog.js
@@ -3,20 +3,16 @@ const Task = require('data.task');
 
 const emptyString = i => /^\s*$/.test(i);
 
-const createEvent = (type, name, data = {}) => {
+const createEvent = (type, data = {}) => {
   if (!R.is(String, type) || emptyString(type)) {
     throw new Error('eventType must be a valid string');
   }
 
-  if (!R.is(String, name) || emptyString(name)) {
-    throw new Error('name must be a valid string');
-  }
-
-  return { type, name, data };
+  return { type, data };
 };
 
-const eventLogger = R.curry((events, type, name, data) => {
-  events.push(createEvent(type, name, data));
+const eventLogger = R.curry((events, type,  data) => {
+  events.push(createEvent(type, data));
 
   return Task.of(data);
 });

--- a/test/createEventLog.js
+++ b/test/createEventLog.js
@@ -1,0 +1,10 @@
+const createEventLog = require('../src/createEventLog.js');
+
+
+describe('event log', () => {
+  it('should work without the name', () => {
+    const logger = createEventLog();
+    logger.debug('sample message');
+    logger.events[0].data.should.equal('sample message');
+  });
+});


### PR DESCRIPTION
update of the documentation
remove the name of the event in the logging, all logging information can be contained in the data object for the logger