### PR TITLE
Ammend quick start instructions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "sinon": "^2.1.0"
   },
   "dependencies": {
+    "chalk": "^1.1.3",
     "data.task": "^3.1.1",
     "easy-immutable": "0.0.3",
     "logfmt": "^1.2.0",

--- a/readme.md
+++ b/readme.md
@@ -25,10 +25,12 @@ returns an arbitary object representing the output.
 
 ```javascript
 // Simple stage that returns an object with a property called foo.
-const stageFoo = context = ( { foo: 'a' });
+const stageFoo = context => ( { foo: 'f' });
+stageFoo.config = { name: 'my-foo-stage' };
 
 // Another stage that return an object with a property called bar.
-const stageBar = context = ( { bar: 'b' });
+const stageBar = context => ( { bar: 'b' });
+stageBar.config = { name: 'my-bar-stage' };
 ```
 
 Once we have the stages, we can call ```createPipeline``` function to bind them 
@@ -121,7 +123,7 @@ const pipeline = createPipeline(readFileStage);
 pipeline().fork(console.error, console.log);
 
 // returns: { file: 'content of /etc/passwd' }
-``` 
+```
 
 Other option is a stage function that returns a ```Promise```.
 


### PR DESCRIPTION
* Added chalk dependency which is required by the consoleLogger
* Stages should have a config property with a name property in order to be invoked using the quick start instructions