### PR TITLE
Merge in context with base property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,14 @@ const invokeStage = (fn, config) => {
         // Append the props to context.
         let appended;
         if (R.is(Object, props)) {
-          appended = ctx.appendToContext(context, props);
+          let resultProps;
+          if (config.useNameAsObject) {
+            resultProps = {}
+            resultProps[config.name] = props
+          } else {
+            resultProps = props
+          }
+          appended = ctx.appendToContext(context, resultProps)
         } else {
           const w = {};
           w[config.name] = props;


### PR DESCRIPTION
## Idea of improvement

If we create stage with reusable function, we'll meet problem with "props already exists". I made small improvement by adding property to configuration of stageFunction.

## Example

Now we can merge context of same functions

### Code

```javascript
const createPipeline = require('./easy-pipeline/src/index')
const stageA = name => {
  const stage = context => {
    if (context.props.bar) {
      return { bara: 'b' }
    } else
      return { bar: 'b' }
  }
  stage.config = { name }
  stage.config.useNameAsObject = true

  return stage
}

createPipeline(stageA('test'), stageA('test2'))().fork(err => console.error(err), r => console.log(r))
````

### Result

So after this we'll receive such result:
```bash
{ test: { bar: 'b' }, test2: { bar: 'b' } }
```

## Where to use

As you can see, there is no problem with same logic but different names. I would like to use your pipeline, for example, for telegram bot integration. I'll have stage "sendMessage", which returns telegram bot api's result. 

I want to be able to call this stage multiple times in single pipelines and use result of every execution in context and have possibility to use it

## Small (really big) problem

I can't make your tests passing. Even without my updates tests
check/easy-pipeline/test/index.js:329
and 
check/easy-pipeline/test/index.js:336

Are failing and I can't understand that's wrong.

Thank you!

